### PR TITLE
Fix biometry access constraints

### DIFF
--- a/agent/src/ios/keychain.ts
+++ b/agent/src/ios/keychain.ts
@@ -247,7 +247,7 @@ const decodeAcl = (entry: NSDictionary): string => {
               break;
 
             case "cbio":
-              constraints.objectForKey_("cbio").count() === 1 ?
+              constraints.objectForKey_("cbio").count().valueOf() === 1 ?
                 flags.push("kSecAccessControlBiometryAny") :
                 flags.push("kSecAccessControlBiometryCurrentSet");
               break;


### PR DESCRIPTION
You are using the strict equality, but compare different types, so the result would be always "false"(kSecAccessControlBiometryCurrentSet)

typeof(constraints.objectForKey_("cbio").count()) is an object
typeof(1) is a number

